### PR TITLE
Fix diff range in version bump workflow

### DIFF
--- a/.github/workflows/bump-playbook-version.yml
+++ b/.github/workflows/bump-playbook-version.yml
@@ -24,7 +24,8 @@ jobs:
           echo "Último arquivo: $latest_file"
 
           # Verifica se o último arquivo foi modificado neste push
-          if git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA" | grep -q "$latest_file"; then
+          changes=$(git diff --name-only "${{ github.event.before }}" "$GITHUB_SHA")
+          if echo "$changes" | grep -q "$latest_file"; then
             current_version=$(echo "$latest_file" | sed -E 's/.*_v([0-9]+)\.yaml/\1/')
             next_version=$((current_version+1))
             new_file="n8n_cloud_playbook_v${next_version}.yaml"


### PR DESCRIPTION
## Summary
- improve `bump-playbook-version.yml` by checking the entire push range for changes

## Testing
- `ruby -ryaml -e 'YAML.load_file("n8n_cloud_playbook_v12.yaml"); puts "v12 OK"'`
- `ruby -ryaml -e 'YAML.load_file("n8n_cloud_playbook_v13.yaml"); puts "v13 OK"'`


------
https://chatgpt.com/codex/tasks/task_e_6882f894ed98832eb38f0ca4fabe94d4